### PR TITLE
PostJobBash v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@
 `PostJobBash` is `Bash@3` based task that allows you to executes bash scripts (across platforms) in the `post-job` phase of the job!
 
 > [!NOTE]  
-> The `PostJobBash` is based on Microsoft's `Bash@3` (https://github.com/microsoft/azure-pipelines-tasks/tree/master/Tasks/BashV3) version `3.237.0` therefore supports the same APIs (https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/bash-v3?view=azure-pipelines)
+> The `PostJobBash` is based on Microsoft's `Bash@3` (https://github.com/microsoft/azure-pipelines-tasks/tree/master/Tasks/BashV3) version `3.259.0` therefore supports the same APIs (https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/bash-v3?view=azure-pipelines)
 
 ## Examples
 > Exiting job
 ```yml
-- task: PostJobBash@1
+- task: PostJobBash@2
   displayName: Exit log
   inputs:
     targetType: 'inline'
@@ -21,7 +21,7 @@
 ```
 > Clean workspace after the pipeline executes
 ```yml
-- task: PostJobBash@1
+- task: PostJobBash@2
   displayName: Clean workspace
   env:
     PIPELINE_WORKSPACE: $(Pipeline.Workspace)

--- a/task/helpers.ts
+++ b/task/helpers.ts
@@ -159,7 +159,7 @@ function findEnclosingBraceIndex(input: string, targetIndex: number) {
     return 0
 }
 
-function isValidEnvName(envName: string) {
+function isValidEnvName(envName) {
     const regex = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
     return regex.test(envName);
 }

--- a/task/package.json
+++ b/task/package.json
@@ -1,6 +1,6 @@
 {
   "name": "post-job-bash",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "PostJobBash is a Bash@3 based task that allows you to executes bash scripts (across platforms) in the post-job phase of the job!",
   "main": "bash.js",
   "scripts": {
@@ -10,13 +10,13 @@
   "author": "Tsvetiliyan Yankov",
   "license": "MIT",
   "dependencies": {
-    "@types/node": "^16.11.39",
-    "azure-pipelines-task-lib": "^4.10.1",
-    "azure-pipelines-tasks-utility-common": "^3.235.0",
+    "@types/node": "^20.3.1",
+    "azure-pipelines-task-lib": "^4.17.3",
+    "azure-pipelines-tasks-utility-common": "3.258.0",
     "uuid": "^3.0.1"
   },
   "devDependencies": {
     "@tsconfig/node10": "1.0.9",
-    "typescript": "^4.0.2"
+    "typescript": "5.1.6"
   }
 }

--- a/task/task.json
+++ b/task/task.json
@@ -16,10 +16,11 @@
     ],
     "author": "Tsvetiliyan Yankov",
     "version": {
-      "Major": 1,
+      "Major": 2,
       "Minor": 0,
-      "Patch": 6
+      "Patch": 0
     },
+    "releaseNotes": "Update the base to Bash@3 version 3.259.0",
     "minimumAgentVersion": "2.115.0",
     "instanceNameFormat": "Post-Job Bash Script",
     "showEnvironmentVariables": true,
@@ -108,6 +109,10 @@
         "argumentFormat": ""
       },
       "Node16": {
+        "target": "bash.js",
+        "argumentFormat": ""
+      },
+      "Node20_1": {
         "target": "bash.js",
         "argumentFormat": ""
       }

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "post-job-bash",
     "name": "Post Job Bash",
-    "version": "1.0.6",
+    "version": "2.0.0",
     "publisher": "tsvetilian",
     "public": true,
     "content": {


### PR DESCRIPTION
**Updated component:**
- Updated base to `Bash@3` version 3.259
- Update nodejs support (closes #2)

**Usage example for v2:**
```yml
- task: PostJobBash@2
  displayName: Exit log
  inputs:
    targetType: 'inline'
    script: |
      echo "Exiting the job!"
```